### PR TITLE
CI(docker-compose): Add platform option with `linux/amd64`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       args:
         - DEV=true
+    platform: linux/amd64
     ports:
       - "8000:8000"
       - "3000:3000" # debugger
@@ -22,18 +23,17 @@ services:
       - DB_PASSWORD=${DB_PASSWORD}
       - PYDEVD_DISABLE_FILE_VALIDATION=1
     env_file:
-      - .env  
+      - .env
     depends_on:
       - db
-    
 
   db: # PostgreSQL Database
-   image: postgres:16-alpine
-   volumes: 
-     - ./data/db:/var/lib/postgresql/data
-   environment:
-     - POSTGRES_DB=${POSTGRES_DB}
-     - POSTGRES_USER=${POSTGRES_USER}
-     - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-   env_file:
-      - .env  
+    image: postgres:16-alpine
+    volumes:
+      - ./data/db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    env_file:
+      - .env


### PR DESCRIPTION
M1 mac에서도 이젠 도커 컴포즈 빌드가 된답니다! 

참조: https://velog.io/@m0ai/M1-맥에서-x8664-도커-이미지-빌드-설정하기